### PR TITLE
4 motor position

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ The ```type``` Can be either ```PICOS```, ```NANOS```, ```MICROS_PLUS```
         "description": "Light Sensor",
         "type": "LIGHT"
       }
+      {
+        "number": 2,
+        "description": "General Analog Sensor 1",
+        "type": "GAS",
+        "gas_type": "4-20ma",
+        "gas_min": 0,
+        "gas_max": 14,
+        "gas_decimals": 2
+      }
     ],
     "COND": [
       {
@@ -439,13 +448,35 @@ mosquitto_sub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
 
 ## Sensor
 
-You can only listen to sensor values.
+NOTE: For now, you can only listen to sensor values.
+
+The following sensor types are currently supported:
+
+```
+TEMPERATURE : Teletask temperature sensor (TDS12250, TDS12251). Value is in °C.
+HUMIDITY    : Teletask humidity sensor (TDS12260). Value is in %.
+LIGHT       : Teletask light sensor (TDS12270). Value is in Lux.
+GAS         : Teletask General Analog Sensor.
+```
 
 ### Listen to events
 
 ```
 mosquitto_sub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
     -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/sensor/1/state
+```
+
+### Sensor types with parameters:
+
+#### General Analog Sensor (GAS)
+
+This sensor has 4 possible config parameters:
+
+```
+gas_type     : One of the 4 possible signal options: "4-20ma", "0-20ma", "0-10V" or "5-10V"
+gas_min      : The "Min" value (see PROSOFT configuration)
+gas_max      : The "Max" value (see PROSOFT configuration)
+gas_decimals : How many decimals you want returned (rounded up)
 ```
 
 # HomeAssistant

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/ConfigurationSupport.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/ConfigurationSupport.java
@@ -35,7 +35,7 @@ public abstract class ConfigurationSupport<T, C extends Configurable<T>, K> {
 
         byte[] dataBytes = ArrayUtils.subarray(payload, startIndex, payload.length);
 
-        ComponentState state = stateCalculator.toComponentState(dataBytes);
+        ComponentState state = stateCalculator.toComponentState(component, dataBytes);
 
         LOG.trace("Parsed state {} to {}", Bytes.bytesToHex(dataBytes), state);
 

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/GasStateCalculator.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/GasStateCalculator.java
@@ -8,25 +8,24 @@ public class GasStateCalculator extends SimpleStateCalculator {
         super(numberConverter);
     }
 
-    @Override
     public String convertGet(ComponentSpec component, byte[] value) {
         short base = this.getNumberConverter().convert(value).shortValue();
         float mMax = component.getGas_max();
         float mMin = component.getGas_min();
-        float value = 0;
+        float gas_value = 0;
         switch (component.getGas_type()) {
             case "4-20ma":
-                value = (mMax - mMin) / 704.0f * (base - 176) + mMin;
+                gas_value = (mMax - mMin) / 704.0f * (base - 176) + mMin;
                 break;
             case "0-10v":
             case "5-10v":
-                value = (mMax - mMin) / 1023.0f * base + mMin;
+                gas_value = (mMax - mMin) / 1023.0f * base + mMin;
                 break;
             case "0-20ma":
-                value = (mMax - mMin) / 880.0f * base + mMin;
+                gas_value = (mMax - mMin) / 880.0f * base + mMin;
                 break;
         }
 
-        return String.valueOf(value);
+        return String.valueOf(gas_value);
     }
 }

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/GasStateCalculator.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/GasStateCalculator.java
@@ -1,0 +1,32 @@
+package io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator;
+
+import io.github.ridiekel.jeletask.client.builder.composer.config.NumberConverter;
+import io.github.ridiekel.jeletask.client.spec.ComponentSpec;
+
+public class GasStateCalculator extends SimpleStateCalculator {
+    public GasStateCalculator(NumberConverter numberConverter) {
+        super(numberConverter);
+    }
+
+    @Override
+    public String convertGet(ComponentSpec component, byte[] value) {
+        short base = this.getNumberConverter().convert(value).shortValue();
+        float mMax = component.getGas_max();
+        float mMin = component.getGas_min();
+        float value = 0;
+        switch (component.getGas_type()) {
+            case "4-20ma":
+                value = (mMax - mMin) / 704.0f * (base - 176) + mMin;
+                break;
+            case "0-10v":
+            case "5-10v":
+                value = (mMax - mMin) / 1023.0f * base + mMin;
+                break;
+            case "0-20ma":
+                value = (mMax - mMin) / 880.0f * base + mMin;
+                break;
+        }
+
+        return String.valueOf(value);
+    }
+}

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/GasStateCalculator.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/GasStateCalculator.java
@@ -7,25 +7,26 @@ public class GasStateCalculator extends SimpleStateCalculator {
     public GasStateCalculator(NumberConverter numberConverter) {
         super(numberConverter);
     }
-
-    public String convertGet(ComponentSpec component, byte[] value) {
-        short base = this.getNumberConverter().convert(value).shortValue();
+    
+    @Override
+    public ComponentState toComponentState(ComponentSpec component, byte[] dataBytes) {
+        long longValue = this.getNumberConverter().convert(dataBytes).longValue();
         float mMax = component.getGas_max();
         float mMin = component.getGas_min();
         float gas_value = 0;
         switch (component.getGas_type()) {
             case "4-20ma":
-                gas_value = (mMax - mMin) / 704.0f * (base - 176) + mMin;
+                gas_value = (mMax - mMin) / 704.0f * (longValue - 176) + mMin;
                 break;
             case "0-10v":
             case "5-10v":
-                gas_value = (mMax - mMin) / 1023.0f * base + mMin;
+                gas_value = (mMax - mMin) / 1023.0f * longValue + mMin;
                 break;
             case "0-20ma":
-                gas_value = (mMax - mMin) / 880.0f * base + mMin;
+                gas_value = (mMax - mMin) / 880.0f * longValue + mMin;
                 break;
         }
 
-        return String.valueOf(gas_value);
+        return new ComponentState(Math.round(gas_value));
     }
 }

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/LuxStateCalculator.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/LuxStateCalculator.java
@@ -10,7 +10,7 @@ public class LuxStateCalculator extends SimpleStateCalculator {
     }
 
     @Override
-    public ComponentState toComponentState(byte[] dataBytes) {
+    public ComponentState toComponentState(ComponentSpec component, byte[] dataBytes) {
         long longValue = this.getNumberConverter().convert(dataBytes).longValue();
         double exponent = longValue / 40d;
         double powered = Math.pow(10, exponent);

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/MappingStateCalculator.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/MappingStateCalculator.java
@@ -27,7 +27,7 @@ public class MappingStateCalculator extends SimpleStateCalculator {
     }
 
     @Override
-    public ComponentState toComponentState(byte[] dataBytes) {
+    public ComponentState toComponentState(ComponentSpec component, byte[] dataBytes) {
         return new ComponentState(this.byNumber.get(this.getNumberConverter().convert(dataBytes).intValue()));
     }
 

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/MotorStateCalculator.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/MotorStateCalculator.java
@@ -35,9 +35,9 @@ public class MotorStateCalculator extends MappingStateCalculator {
 
     @Override
     public ComponentState toComponentState(ComponentSpec component, byte[] dataBytes) {
-        ComponentState state = new ComponentState(MOTOR_STATE_CALCULATOR.toComponentState(new byte[]{dataBytes[1]}).getState());
-        state.setLastDirection(super.toComponentState(dataBytes).getState());
-        state.setProtection(PROTECTION_STATE_CALCULATOR.toComponentState(new byte[]{dataBytes[2]}).getState());
+        ComponentState state = new ComponentState(MOTOR_STATE_CALCULATOR.toComponentState(component, new byte[]{dataBytes[1]}).getState());
+        state.setLastDirection(super.toComponentState(component, dataBytes).getState());
+        state.setProtection(PROTECTION_STATE_CALCULATOR.toComponentState(component, new byte[]{dataBytes[2]}).getState());
         state.setPosition(NumberConverter.UNSIGNED_BYTE.convert(new byte[]{dataBytes[3]}));
         if (dataBytes.length > 4) {
             state.setPosition(NumberConverter.UNSIGNED_BYTE.convert(new byte[]{dataBytes[4]}));

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/MotorStateCalculator.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/MotorStateCalculator.java
@@ -34,7 +34,7 @@ public class MotorStateCalculator extends MappingStateCalculator {
     }
 
     @Override
-    public ComponentState toComponentState(byte[] dataBytes) {
+    public ComponentState toComponentState(ComponentSpec component, byte[] dataBytes) {
         ComponentState state = new ComponentState(MOTOR_STATE_CALCULATOR.toComponentState(new byte[]{dataBytes[1]}).getState());
         state.setLastDirection(super.toComponentState(dataBytes).getState());
         state.setProtection(PROTECTION_STATE_CALCULATOR.toComponentState(new byte[]{dataBytes[2]}).getState());

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/PulseCounterStateCalculator.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/PulseCounterStateCalculator.java
@@ -36,6 +36,7 @@ public class PulseCounterStateCalculator extends SimpleStateCalculator {
 
 
          */
+        return new ComponentState("TODO");
     }
 }
 

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/PulseCounterStateCalculator.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/PulseCounterStateCalculator.java
@@ -1,0 +1,42 @@
+package io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator;
+
+import io.github.ridiekel.jeletask.client.builder.composer.config.NumberConverter;
+import io.github.ridiekel.jeletask.client.spec.ComponentSpec;
+import io.github.ridiekel.jeletask.client.spec.state.ComponentState;
+
+public class PulseCounterStateCalculator extends SimpleStateCalculator {
+
+    public PulseCounterStateCalculator(NumberConverter numberConverter) {
+        super(numberConverter);
+    }
+
+    @Override
+    public ComponentState toComponentState(ComponentSpec component, byte[] dataBytes) {
+        /*
+
+    private double GetDisplayValue(final int val, final boolean realtime, final byte decimals) {
+        if (val == 0) {
+            return 0.0;
+        }
+        double waarde;
+        if (realtime) {
+            if (!this.mShowRealTime) {
+                waarde = val * (1000.0 / this.mPulsePerUnit);
+            }
+            else {
+                waarde = val * (this.mRtUnitsPerUnit * (double)this.SecondsPerTimeBase(this.mTimeBase)) / (3600.0 * this.mPulsePerUnit);
+            }
+        }
+        else {
+            waarde = val / (double)this.mPulsePerUnit;
+        }
+        final int temp = (int)(waarde * Math.pow(10.0, decimals));
+        return temp / Math.pow(10.0, decimals);
+    }
+
+
+         */
+    }
+}
+
+

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/SensorStateCalculator.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/SensorStateCalculator.java
@@ -46,7 +46,7 @@ public class SensorStateCalculator extends SimpleStateCalculator {
             LOG.warn(String.format("State calculator not found for component:\n\n        %s\n", component));
             return new StateCalculator() {
                 @Override
-                public ComponentState toComponentState(byte[] value) {
+                public ComponentState toComponentState(ComponentSpec component, byte[] value) {
                     return null;
                 }
 

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/SensorStateCalculator.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/SensorStateCalculator.java
@@ -26,7 +26,7 @@ public class SensorStateCalculator extends SimpleStateCalculator {
     }
 
     @Override
-    public ComponentState toComponentState(byte[] dataBytes) {
+    public ComponentState toComponentState(ComponentSpec component, byte[] dataBytes) {
         throw new IllegalStateException("Should not get here");
     }
 

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/SensorStateCalculator.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/SensorStateCalculator.java
@@ -15,12 +15,13 @@ public class SensorStateCalculator extends SimpleStateCalculator {
 
     private final Map<String, StateCalculator> sensorTypeCalculators;
 
-    public SensorStateCalculator(StateCalculator temperature, StateCalculator lux, StateCalculator humidity) {
+    public SensorStateCalculator(StateCalculator temperature, StateCalculator lux, StateCalculator humidity, StateCalculator gas) {
         super(temperature.getNumberConverter());
         this.sensorTypeCalculators = Map.of(
                 "TEMPERATURE", temperature,
                 "LIGHT", lux,
-                "HUMIDITY", humidity
+                "HUMIDITY", humidity,
+                "GAS", gas
         );
     }
 

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/SimpleStateCalculator.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/SimpleStateCalculator.java
@@ -13,7 +13,7 @@ public class SimpleStateCalculator implements StateCalculator {
     }
 
     @Override
-    public ComponentState toComponentState(byte[] dataBytes) {
+    public ComponentState toComponentState(ComponentSpec component, byte[] dataBytes) {
         Number number = this.numberConverter.convert(dataBytes);
         return new ComponentState(number.intValue() == -1 ? 255 : number);
     }

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/StateCalculator.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/StateCalculator.java
@@ -5,7 +5,7 @@ import io.github.ridiekel.jeletask.client.spec.ComponentSpec;
 import io.github.ridiekel.jeletask.client.spec.state.ComponentState;
 
 public interface StateCalculator {
-    ComponentState toComponentState(byte[] dataBytes);
+    ComponentState toComponentState(ComponentSpec component, byte[] dataBytes);
 
     byte[] toBytes(ComponentState state);
 

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/TemperatureStateCalculator.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/TemperatureStateCalculator.java
@@ -15,7 +15,7 @@ public class TemperatureStateCalculator extends SimpleStateCalculator {
     }
 
     @Override
-    public ComponentState toComponentState(byte[] dataBytes) {
+    public ComponentState toComponentState(ComponentSpec component, byte[] dataBytes) {
         long base = this.getNumberConverter().convert(dataBytes).longValue();
         double divided = base / this.divide;
         double subtracted = divided - this.subtract;

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/microsplus/MicrosPlusFunctionConfiguration.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/microsplus/MicrosPlusFunctionConfiguration.java
@@ -5,6 +5,7 @@ import io.github.ridiekel.jeletask.client.builder.composer.config.NumberConverte
 import io.github.ridiekel.jeletask.client.builder.composer.config.configurables.FunctionConfigurable;
 import io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator.DimmerStateCalculator;
 import io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator.HumidityStateCalculator;
+import io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator.GasStateCalculator;
 import io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator.LuxStateCalculator;
 import io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator.MotorStateCalculator;
 import io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator.OnOffToggleStateCalculator;
@@ -30,7 +31,8 @@ public class MicrosPlusFunctionConfiguration extends ConfigurationSupport<Functi
                 new FunctionConfigurable(Function.SENSOR, 20, new SensorStateCalculator(
                         new TemperatureStateCalculator(NumberConverter.UNSIGNED_SHORT, 10, 273),
                         new LuxStateCalculator(NumberConverter.UNSIGNED_SHORT),
-                        new HumidityStateCalculator(NumberConverter.UNSIGNED_SHORT)
+                        new HumidityStateCalculator(NumberConverter.UNSIGNED_SHORT),
+                        new GasStateCalculator(NumberConverter.UNSIGNED_SHORT)
                 )),
                 new FunctionConfigurable(Function.COND, 60, ON_OFF_TOGGLE)
         ));

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/spec/ComponentSpec.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/spec/ComponentSpec.java
@@ -16,10 +16,10 @@ public class ComponentSpec  {
     private String type;
     
     // For GAS (General Analog Sensor)
-    private String gas_type;
-    private float gas_min;
-    private float gas_max;
-    private int gas_decimals;
+    private String gas_type = "";
+    private float gas_min = 0;
+    private float gas_max = 0;
+    private int gas_decimals = 0;
 
     /**
      * Default constructor.

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/spec/ComponentSpec.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/spec/ComponentSpec.java
@@ -19,6 +19,7 @@ public class ComponentSpec  {
     private String gas_type;
     private float gas_min;
     private float gas_max;
+    private int gas_decimals;
 
     /**
      * Default constructor.
@@ -94,4 +95,8 @@ public class ComponentSpec  {
     public float getGas_max() { return this.gas_max; }
 
     public void setGas_max(float gas_max) { this.gas_max = gas_max; }
+    
+    public int getGas_decimals() { return this.gas_decimals; }
+
+    public void setGas_decimals(int gas_decimals) { this.gas_decimals = gas_decimals; }
 }

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/spec/ComponentSpec.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/spec/ComponentSpec.java
@@ -14,6 +14,11 @@ public class ComponentSpec  {
     private int number;
     private ComponentState state;
     private String type;
+    
+    // For GAS (General Analog Sensor)
+    private String gas_type;
+    private float gas_min;
+    private float gas_max;
 
     /**
      * Default constructor.
@@ -77,4 +82,16 @@ public class ComponentSpec  {
     public void setType(String type) {
         this.type = type;
     }
+    
+    public String getGas_type() { return this.gas_type; }
+
+    public void setGas_type(String gas_type) { this.gas_type = gas_type; }
+
+    public float getGas_min() { return this.gas_min; }
+
+    public void setGas_min(float gas_min) { this.gas_min = gas_min; }
+
+    public float getGas_max() { return this.gas_max; }
+
+    public void setGas_max(float gas_max) { this.gas_max = gas_max; }
 }

--- a/jeletask2mqtt/src/main/java/io/github/ridiekel/jeletask/mqtt/listener/homeassistant/types/HAMotorConfig.java
+++ b/jeletask2mqtt/src/main/java/io/github/ridiekel/jeletask/mqtt/listener/homeassistant/types/HAMotorConfig.java
@@ -13,8 +13,11 @@ public class HAMotorConfig extends HAReadWriteConfig<HAMotorConfig> {
         this.putInt("position_closed", 100);
         this.put("optimistic", "false");
         this.put("payload_open", "UP");
+        this.put("state_open", "UP");
         this.put("payload_close", "DOWN");
+        this.put("state_closed", "DOWN");
         this.put("payload_stop", "STOP");
+        this.put("state_stopped", "STOP");
         this.put("position_template", "{{ value_json.position }}");
         this.put("value_template", "{% if value_json.state == 'OFF' %}STOP{% else %}value_json.last_direction{% endif %}");
     }


### PR DESCRIPTION
Added support for General Analog Sensors.

Example configuration:

```
   "SENSOR": [
      {
        "number": 119,
        "description": "Pool ORP",
        "type": "GAS",
        "gas_type": "4-20ma",
        "gas_min": -2000,
        "gas_max": 2000,
        "gas_decimals": 0
      },
      {
        "number": 118,
        "description": "Pool PH",
        "type": "GAS",
        "gas_type": "4-20ma",
        "gas_min": 0,
        "gas_max": 14,
        "gas_decimals": 2
      }
    ],
```
