### PR TITLE
Add option to set dimmers to previous brightness level

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ mosquitto_sub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
 
 #### Turning on
 
-For turning on you can use `ON` (goes to 100%) or `OFF` (goes to 0%) or any integer value between `0` and `100`
+For turning on you can use `ON` (goes to 100%), `OFF` (goes to 0%), 'PREVIOUS_STATE' (goes to last %) or any integer value between `0` and `100`
 
 ```
 mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ mosquitto_sub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
 
 #### Turning on
 
-For turning on you can use `ON` (goes to 100%), `OFF` (goes to 0%), 'PREVIOUS_STATE' (goes to last %) or any integer value between `0` and `100`
+For turning on you can use `ON` (goes to 100%), `OFF` (goes to 0%), `PREVIOUS_STATE` (goes to last %) or any integer value between `0` and `100`
 
 ```
 mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/DimmerStateCalculator.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/DimmerStateCalculator.java
@@ -4,7 +4,7 @@ import io.github.ridiekel.jeletask.client.builder.composer.config.NumberConverte
 import io.github.ridiekel.jeletask.client.spec.ComponentSpec;
 import io.github.ridiekel.jeletask.client.spec.state.ComponentState;
 
-public class DimmerStateCalculator extends PercentageStateCalculator {
+public class DimmerStateCalculator extends SimpleStateCalculator {
     public DimmerStateCalculator(NumberConverter numberConverter) {
         super(numberConverter);
     }
@@ -13,4 +13,11 @@ public class DimmerStateCalculator extends PercentageStateCalculator {
     public ComponentState getDefaultState(ComponentSpec component) {
         return new ComponentState("50");
     }
+
+    @Override
+    public boolean isValidState(ComponentState state) {
+        long value = Long.parseLong(state.getState());
+        return value == 103 || (value >= 0 && value <= 100);
+    }
 }
+

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/spec/state/ComponentState.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/spec/state/ComponentState.java
@@ -125,6 +125,7 @@ public class ComponentState {
 
         simpleValueMapper(Function.DIMMER).put("ON", s -> stateTemplate("100"));
         simpleValueMapper(Function.DIMMER).put("OFF", s -> stateTemplate("0"));
+        simpleValueMapper(Function.DIMMER).put("PREVIOUS_STATE", s -> stateTemplate("103"));
         IntStream.range(0, 101).forEach(i -> simpleValueMapper(Function.DIMMER).put(String.valueOf(i), ComponentState::stateTemplate));
     }
 


### PR DESCRIPTION
Teletask dimmers can be set to "103" which is used for setting the light to it's previous brightness level.
This PR brings support for this to jeletask.