### PR TITLE
Please read the description BEFORE merging 👍 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ An open source java API for Teletask domotics.
 
 It is the purpose to create an API for software developers or domotics enthusiasts, who are interested in generating their own control environment for the TELETASK domotics systems, so you can create your own user interface and connected solutions and services.
 
-If you own a Teletask MICROS or MICROS+, you have access to the free (or paid in case of the MICROS+) DLL32 LIBRARY (TDS15132).  
+If you own a Teletask MICROS+, you need the (paid) DLL32 LIBRARY (TDS15132).  
 However, if you're a java programmer like myself, you don't want to use a windows dll :-).
 
 Teletask documentation on how their API works can be found here: https://teletask.be/media/3109/tds15132-library.pdf
 
-The program supports the MICROS+ (maybe also PICOS, but untested), but you'll have to buy a licence to be able to make TCP calls.
+The program supports the MICROS+ (maybe also NANOS/PICOS, but untested), but you'll have to buy a licence to be able to make TCP calls.
 
 You can find the latest docker images at: https://hub.docker.com/r/ridiekel/jeletask2mqtt
 
@@ -117,10 +117,9 @@ The ```type``` Can be either ```PICOS```, ```NANOS```, ```MICROS_PLUS```
     "TIMEDFNC": [
       {
         "number": 3,
-        "description": "Timed function nr 3"
+        "description": "Timed function nr 3 (pulse for garage door)"
       }
     ],
-    // TODO: Write documentation for DISPLAYMESSAGE. bus_numbers+address_numbers -> see PDF for explanation
     "DISPLAYMESSAGE": [
       {
         "number": 1000,
@@ -242,22 +241,10 @@ mosquitto_sub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
 ```
 mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
     -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/relay/1/set \
-    -m "ON"
-```
-or
-```
-mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
-    -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/relay/1/set \
     -m '{"state":"ON"}'
 ```
 
 #### Turning off
-```
-mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
-    -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/relay/1/set \
-    -m "OFF"
-```
-or
 ```
 mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
     -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/relay/1/set \
@@ -279,22 +266,10 @@ mosquitto_sub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
 ```
 mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
     -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/locmood/1/set \
-    -m "ON"
-```
-or
-```
-mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
-    -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/locmood/1/set \
     -m '{"state":"ON"}'
 ```
 
 #### Turning off
-```
-mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
-    -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/locmood/1/set \
-    -m "OFF"
-```
-or
 ```
 mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
     -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/locmood/1/set \
@@ -316,22 +291,10 @@ mosquitto_sub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
 ```
 mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
     -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/genmood/1/set \
-    -m "ON"
-```
-or
-```
-mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
-    -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/genmood/1/set \
     -m '{"state":"ON"}'
 ```
 
 #### Turning off
-```
-mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
-    -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/genmood/1/set \
-    -m "OFF"
-```
-or
 ```
 mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
     -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/genmood/1/set \
@@ -356,19 +319,7 @@ For turning on you can use `ON` (goes to 100%), `OFF` (goes to 0%), `PREVIOUS_ST
 ```
 mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
     -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/dimmer/1/set \
-    -m "ON"
-```
-or
-```
-mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
-    -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/dimmer/1/set \
     -m '{"state":"ON"}'
-```
-
-```
-mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
-    -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/dimmer/1/set \
-    -m "60"
 ```
 or
 ```
@@ -383,20 +334,7 @@ For turning off, you can use either `OFF` or `0`
 ```
 mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
     -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/dimmer/1/set \
-    -m "OFF"
-```
-or
-```
-mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
-    -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/dimmer/1/set \
     -m '{"state":"OFF"}'
-```
-
-
-```
-mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
-    -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/dimmer/1/set \
-    -m "0"
 ```
 or
 ```
@@ -423,24 +361,6 @@ You can send either `UP`, `DOWN` or `STOP` to the motor function.
 ```
 mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
     -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/motor/1/set \
-    -m "UP"
-```
-
-```
-mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
-    -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/motor/1/set \
-    -m "STOP"
-```
-
-```
-mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
-    -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/motor/1/set \
-    -m "DOWN"
-```
-or
-```
-mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
-    -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/motor/1/set \
     -m '{"state":"UP"}'
 ```
 
@@ -464,12 +384,6 @@ Position can be anything between `0` and `100`.
 ```
 mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
     -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/motor/1/set \
-    -m "25"
-```
-or
-```
-mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
-    -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/motor/1/set \
     -m '{"position": 25}'
 ```
 
@@ -487,12 +401,6 @@ mosquitto_sub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
 ```
 mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
     -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/flag/1/set \
-    -m "ON"
-```
-or
-```
-mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
-    -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/flag/1/set \
     -m '{"state":"ON"}'
 ```
 
@@ -500,18 +408,10 @@ mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
 ```
 mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
     -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/flag/1/set \
-    -m "OFF"
-```
-or
-```
-mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
-    -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/flag/1/set \
     -m '{"state":"OFF"}'
 ```
 
 ## Sensor
-
-NOTE: For now, you can only listen to sensor values.
 
 The following sensor types are currently supported:
 
@@ -528,6 +428,14 @@ GAS                : Teletask General Analog Sensor.
 ```
 mosquitto_sub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
     -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/sensor/1/state
+```
+
+### HA config parameters
+
+The following additional Home Assistant related parameters are available:
+
+```
+ha_unit_of_measurement: To specify a custom 'unit_of_measurement' in HA auto discovery. For example: "°C"
 ```
 
 ### Sensor TEMPERATURECONTROL
@@ -597,12 +505,6 @@ mosquitto_sub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
 ```
 mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
     -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/timedfnc/1/set \
-    -m "ON"
-```
-or
-```
-mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
-    -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/timedfnc/1/set \
     -m '{"state":"ON"}'
 ```
 
@@ -610,14 +512,37 @@ mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
 ```
 mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
     -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/timedfnc/1/set \
-    -m "OFF"
-```
-or
-```
-mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
-    -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/timedfnc/1/set \
     -m '{"state":"OFF"}'
 ```
+
+## Display message
+
+You can only send a display message. Listening for events is not supported.
+
+DISPLAYMESSAGE config attribute parameters:
+
+```
+number          : A unique DISPLAYMESSAGE number 
+bus_numbers     : A list of BUS numbers (see below)
+address_numbers : A list of ADDRESS numbers (see below)
+description     : Description for this config entry
+```
+
+#### What are bus_numbers and address_numbers?
+bus_numbers and addres_numbers are two comma separated lists of the same size.
+They contain the Teletask bus number(s) and Teletask interface address(es) of the interface(s) on which to display the Message/Alarm
+
+#### Sending a display message
+
+```
+mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
+    -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/displaymessage/1000/set \
+    -m '{"message_line1":"DOORBELL","message_line2":"PLEASE OPEN!", "message_beeps":"10","message_type="message"}'
+```
+
+Notes:
+- Both lines each have maximum length of 16 chars. This is a Teletask limitation.
+- message_type can either be "alarm" or "message".
 
 # HomeAssistant
 
@@ -633,7 +558,7 @@ switch.teletask_my_teletask_relay_1
 light.teletask_my_teletask_relay_36
 ```
 
-## Additional config
+## Additional HA config
 
 ### Relay
 

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ or
 ```
 mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
     -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/dimmer/1/set \
-    -m '{"state":60}'
+    -m '{"state":"ON", "brightness": "60"}'
 ```
 
 #### Turning off
@@ -377,7 +377,7 @@ or
 ```
 mosquitto_pub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
     -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/dimmer/1/set \
-    -m '{"state":"0"}'
+    -m '{"brightness":"0"}'
 ```
 
 ## Motor

--- a/README.md
+++ b/README.md
@@ -54,6 +54,22 @@ The ```type``` Can be either ```PICOS```, ```NANOS```, ```MICROS_PLUS```
         "gas_min": 0,
         "gas_max": 14,
         "gas_decimals": 2
+      },
+      {
+        "number": 3,
+        "description": "Temperature Sensor",
+        "type": "TEMPERATURE",
+        "ha_unit_of_measurement": "°C"
+      },
+      {
+        "number": 4,
+        "description": "HVAC / AC",
+        "type": "TEMPERATURECONTROL"
+      },
+      {
+        "number": 5,
+        "description": "Aurus wall switch in the attic",
+        "type": "TEMPERATURECONTROL"
       }
     ],
     "COND": [
@@ -500,10 +516,11 @@ NOTE: For now, you can only listen to sensor values.
 The following sensor types are currently supported:
 
 ```
-TEMPERATURE : Teletask temperature sensor (TDS12250, TDS12251). Value is in °C.
-HUMIDITY    : Teletask humidity sensor (TDS12260). Value is in %.
-LIGHT       : Teletask light sensor (TDS12270). Value is in Lux.
-GAS         : Teletask General Analog Sensor.
+TEMPERATURE        : Teletask temperature sensor (TDS12250, TDS12251). Value is in °C.
+TEMPERATURECONTROL : Teletask temperature controllabe sensor (Aurus OLED, HVAC, ...)
+HUMIDITY           : Teletask humidity sensor (TDS12260). Value is in %.
+LIGHT              : Teletask light sensor (TDS12270). Value is in Lux.
+GAS                : Teletask General Analog Sensor.
 ```
 
 ### Listen to events
@@ -512,6 +529,37 @@ GAS         : Teletask General Analog Sensor.
 mosquitto_sub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
     -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/sensor/1/state
 ```
+
+### Sensor TEMPERATURECONTROL
+
+Use TEMPERATURECONTROL for any temperature controllabe 'sensor' like an AC (HVAC) or an Aurus OLED wall switch 
+
+The following json attributes are provided on the /state MQTT topic: 
+```
+state               : ON/OFF state
+current_temperature : The current temperature
+target_temperature  : The set target temperature
+preset              : The current preset (DAY/NIGHT/STANDBY)
+mode                : The current mode (AUTO/HEAT/COOL/VENT/DRY)
+fanspeed            : The current fan speed (SPAUTO/SPLOW/SPMED/SPHIGH)
+```
+
+The following "state" attribute commands are supported on the /set MQTT topic:
+
+```
+ON (Turn on the device)
+OFF (Turn off the device)
+ONOFF (Toggle on or off the device)
+UP (Set target temperature up 0.5°C)
+DOWN (Set target temperature down 0.5°C)
+For a preset, one of: DAY, NIGHT, STANDBY
+For an operating mode, one of: AUTO, HEAT, COOL, VENT, DRY
+   (or MODE to toggle between the available modes...)
+For a fan speed, one of: SPAUTO, SPLOW, SPMED, SPHIGH
+   (or SPEED to toggle between the available speeds...)
+```
+
+You can also set the target temperature by sending the desired temperature to the "target_temperature" attribute.
 
 ### Sensor types with parameters:
 

--- a/README.md
+++ b/README.md
@@ -91,11 +91,10 @@ The ```type``` Can be either ```PICOS```, ```NANOS```, ```MICROS_PLUS```
         "description": "Spots"
       }
     ],
-    "SERVICE": [
+    "INPUT": [
       {
         "number": 42,
         "description": "State of TDS12117 input nr 3",
-        "service_type": "DIGITALINPUT"
       }
     ],
     "TIMEDFNC": [
@@ -517,21 +516,13 @@ gas_max      : The "Max" value (see PROSOFT configuration)
 gas_decimals : How many decimals you want returned (rounded up)
 ```
 
-## Service function
-
-NOTE: For now, you can only listen to service functions
-
-The following service types are currently supported:
-
-```
-DIGITALINPUT : For example, for the TDS12117 digital input interface. (OPEN / CLOSED)
-```
+## Input (digital inputs)
 
 ### Listen to events
 
 ```
 mosquitto_sub -h <TELETASK_MQTT_HOST> -p <TELETASK_MQTT_PORT> \
-    -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/service/1/state
+    -t <TELETASK_MQTT_PREFIX>/<TELETASK_ID>/input/1/state
 ```
 
 ## Timed function

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ At this time I can only test with MICROS_PLUS. Please log an issue when you are 
 If teletask has not changed their binary API, it should be compatible.
 
 The ```type``` Can be either ```PICOS```, ```NANOS```, ```MICROS_PLUS```
+
 ```json
 {
   "type": "MICROS_PLUS",
@@ -28,7 +29,7 @@ The ```type``` Can be either ```PICOS```, ```NANOS```, ```MICROS_PLUS```
       {
         "number": 1,
         "description": "Power outlet",
-        "type": "switch" 
+        "type": "switch"
       },
       {
         "number": 23,
@@ -94,13 +95,22 @@ The ```type``` Can be either ```PICOS```, ```NANOS```, ```MICROS_PLUS```
     "INPUT": [
       {
         "number": 42,
-        "description": "State of TDS12117 input nr 3",
+        "description": "State of TDS12117 input nr 3"
       }
     ],
     "TIMEDFNC": [
       {
         "number": 3,
         "description": "Timed function nr 3"
+      }
+    ],
+    // TODO: Write documentation for DISPLAYMESSAGE. bus_numbers+address_numbers -> see PDF for explanation
+    "DISPLAYMESSAGE": [
+      {
+        "number": 1000,
+        "bus_numbers": "1,1",
+        "address_numbers": "13,5",
+        "description": "Aurus living room + aurus basement"
       }
     ]
   }

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/TeletaskClient.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/TeletaskClient.java
@@ -13,6 +13,10 @@ public interface TeletaskClient {
 
     void set(Function function, int number, ComponentState state, SuccessConsumer onSucccess, FailureConsumer onFailed);
 
+    void displaymessage(ComponentSpec component, ComponentState state, SuccessConsumer onSuccess, FailureConsumer onFailed);
+
+    void displaymessage(int number, ComponentState state, SuccessConsumer onSucccess, FailureConsumer onFailed);
+
     void get(Function function, int number, SuccessConsumer onSucccess, FailureConsumer onFailed);
 
     void get(ComponentSpec component, SuccessConsumer onSuccess, FailureConsumer onFailed);

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/TeletaskClientImpl.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/TeletaskClientImpl.java
@@ -103,6 +103,20 @@ public final class TeletaskClientImpl implements TeletaskReceiver, TeletaskClien
     }
 
     @Override
+    public void displaymessage(ComponentSpec component, ComponentState state, SuccessConsumer onSuccess, FailureConsumer onFailed) {
+        this.execute(
+                new DisplayMessage(this.getConfig(), component.getFunction(), component.getNumber(), Optional.ofNullable(state).orElseThrow(() -> new IllegalArgumentException("State should not be null"))),
+                m -> onSuccess.execute(component.getFunction(), component.getNumber(), component.getState()),
+                (m, e) -> onFailed.execute(component.getFunction(), component.getNumber(), component.getState(), e)
+        );
+    }
+
+    @Override
+    public void displaymessage(int number, ComponentState state, SuccessConsumer onSucccess, FailureConsumer onFailed) {
+        this.displaymessage(this.getComponent(Function.DISPLAYMESSAGE, number), state, onSucccess, onFailed);
+    }    
+    
+    @Override
     public void get(Function function, int number, SuccessConsumer onSucccess, FailureConsumer onFailed) {
         this.get(this.getComponent(function, number), onSucccess, onFailed);
     }
@@ -236,7 +250,11 @@ public final class TeletaskClientImpl implements TeletaskReceiver, TeletaskClien
     @Override
     public void groupGet() {
         for (Function function : Function.values()) {
-            this.groupGet(function);
+
+            // No group get message for DISPLAYMESSAGE please
+            if (function != Function.DISPLAYMESSAGE)
+
+                this.groupGet(function);
         }
     }
 

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/TeletaskClientImpl.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/TeletaskClientImpl.java
@@ -10,6 +10,7 @@ import io.github.ridiekel.jeletask.client.builder.message.messages.impl.EventMes
 import io.github.ridiekel.jeletask.client.builder.message.messages.impl.GetMessage;
 import io.github.ridiekel.jeletask.client.builder.message.messages.impl.LogMessage;
 import io.github.ridiekel.jeletask.client.builder.message.messages.impl.SetMessage;
+import io.github.ridiekel.jeletask.client.builder.message.messages.impl.DisplayMessage;
 import io.github.ridiekel.jeletask.client.builder.message.strategy.KeepAliveStrategy;
 import io.github.ridiekel.jeletask.client.listener.StateChangeListener;
 import io.github.ridiekel.jeletask.client.spec.CentralUnit;

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/configurables/command/DisplayMessageCommandConfigurable.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/configurables/command/DisplayMessageCommandConfigurable.java
@@ -1,0 +1,20 @@
+package io.github.ridiekel.jeletask.client.builder.composer.config.configurables.command;
+
+import io.github.ridiekel.jeletask.client.builder.composer.MessageHandler;
+import io.github.ridiekel.jeletask.client.builder.composer.config.configurables.CommandConfigurable;
+import io.github.ridiekel.jeletask.client.builder.message.messages.impl.DisplayMessage;
+import io.github.ridiekel.jeletask.client.spec.CentralUnit;
+import io.github.ridiekel.jeletask.client.spec.Command;
+
+public class DisplayMessageCommandConfigurable extends CommandConfigurable<DisplayMessage> {
+
+    public DisplayMessageCommandConfigurable(int number, boolean needsCentralUnitParameter, String... paramNames) {
+        super(Command.DISPLAYMESSAGE, number, needsCentralUnitParameter, paramNames);
+    }
+
+    @Override
+    public DisplayMessage parse(CentralUnit config, MessageHandler messageHandler, byte[] rawBytes, byte[] payload) {
+        // Not implemented. Not needed for DisplayMessage?
+        return null;
+    }
+}

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/AurusStateCalculator.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/AurusStateCalculator.java
@@ -48,7 +48,7 @@ public class AurusStateCalculator extends MappingStateCalculator {
             return null;
 
         ComponentState state = new ComponentState(AURUS_STATE_CALCULATOR.toComponentState(component, new byte[]{dataBytes[12]}).getState());
-        TemperatureStateCalculator tempcalculator = new TemperatureStateCalculator(this.getNumberConverter(), 10, 273);
+        TemperatureStateCalculator tempcalculator = new TemperatureStateCalculator(NumberConverter.UNSIGNED_SHORT, 10, 273);
 
         state.setCurrentTemperature(Float.valueOf(tempcalculator.toComponentState(component, new byte[]{dataBytes[0], dataBytes[1]}).getState()));
         state.setTargetTemperature(Float.valueOf(tempcalculator.toComponentState(component, new byte[]{dataBytes[2], dataBytes[3]}).getState()));
@@ -75,11 +75,7 @@ public class AurusStateCalculator extends MappingStateCalculator {
             setting = super.toBytes(state);
         }
 
-        // TODO: Why is there a 0x00 byte in settings[0]?
-        setting = new byte[]{setting[1]};
-
         return Bytes.concat(setting, data);
-
     }
 
     @Override

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/AurusStateCalculator.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/AurusStateCalculator.java
@@ -22,6 +22,7 @@ public class AurusStateCalculator extends MappingStateCalculator {
 //            new StateMapping("SETSTANDBY", 88),
 //            new StateMapping("SETNIGHT", 27),
 //            new StateMapping("SETNIGHTCOOL", 56),
+//            new StateMapping("TEMPMANUAL_TARGET", 87), // Not verified yet
             new StateMapping("SPEED", 31),
             new StateMapping("SPLOW", 97),
             new StateMapping("SPMED", 98),
@@ -34,6 +35,7 @@ public class AurusStateCalculator extends MappingStateCalculator {
             new StateMapping("VENT", 105),
             new StateMapping("STOP", 106),
             new StateMapping("HEATP", 107),
+            new StateMapping("DRY", 108), // Not verified yet
             new StateMapping("ONOFF", 104)
     );
     public AurusStateCalculator(NumberConverter numberConverter) {
@@ -67,7 +69,7 @@ public class AurusStateCalculator extends MappingStateCalculator {
         byte[] setting = null;
         byte[] data = Bytes.EMPTY;
 
-        // TODO: implement commands with parameters: SETDAY,SETSTANDY,SETNIGHT,SETNIGHTCOOL ?
+        // TODO: implement commands with parameters: SETDAY,SETSTANDY,SETNIGHT,SETNIGHTCOOL,TEMPMANUAL_TARGET
 
         if (setting == null) {
             setting = super.toBytes(state);

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/AurusStateCalculator.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/AurusStateCalculator.java
@@ -1,0 +1,89 @@
+package io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator;
+
+import io.github.ridiekel.jeletask.client.builder.composer.config.NumberConverter;
+import io.github.ridiekel.jeletask.client.spec.ComponentSpec;
+import io.github.ridiekel.jeletask.client.spec.state.ComponentState;
+import io.github.ridiekel.jeletask.utilities.Bytes;
+
+import java.util.List;
+
+public class AurusStateCalculator extends MappingStateCalculator {
+
+    public static final OnOffToggleStateCalculator AURUS_STATE_CALCULATOR = new OnOffToggleStateCalculator(NumberConverter.UNSIGNED_BYTE, 255, 0);
+
+    private static final List<StateMapping> STATE_MAPPINGS = List.of(
+            new StateMapping("UP", 21),
+            new StateMapping("DOWN", 22),
+            new StateMapping("FROST", 24),
+            new StateMapping("DAY", 26),
+            new StateMapping("NIGHT",25 ),
+            new StateMapping("STANDBY", 93),
+//            new StateMapping("SETDAY", 29),
+//            new StateMapping("SETSTANDBY", 88),
+//            new StateMapping("SETNIGHT", 27),
+//            new StateMapping("SETNIGHTCOOL", 56),
+            new StateMapping("SPEED", 31),
+            new StateMapping("SPLOW", 97),
+            new StateMapping("SPMED", 98),
+            new StateMapping("SPHIGH", 99),
+            new StateMapping("SPAUTO", 89),
+            new StateMapping("MODE", 30),
+            new StateMapping("AUTO", 94),
+            new StateMapping("HEAT", 95),
+            new StateMapping("COOL", 96),
+            new StateMapping("VENT", 105),
+            new StateMapping("STOP", 106),
+            new StateMapping("HEATP", 107),
+            new StateMapping("ONOFF", 104)
+    );
+    public AurusStateCalculator(NumberConverter numberConverter) {
+        super(numberConverter, STATE_MAPPINGS.toArray(StateMapping[]::new));
+    }
+
+    @Override
+    public ComponentState toComponentState(ComponentSpec component, byte[] dataBytes) {
+        if (dataBytes.length < 17)
+            return null;
+
+        ComponentState state = new ComponentState(AURUS_STATE_CALCULATOR.toComponentState(component, new byte[]{dataBytes[12]}).getState());
+        TemperatureStateCalculator tempcalculator = new TemperatureStateCalculator(this.getNumberConverter(), 10, 273);
+
+        state.setCurrentTemperature(Float.valueOf(tempcalculator.toComponentState(component, new byte[]{dataBytes[0], dataBytes[1]}).getState()));
+        state.setTargetTemperature(Float.valueOf(tempcalculator.toComponentState(component, new byte[]{dataBytes[2], dataBytes[3]}).getState()));
+
+        // TODO: reverse engineer these additional bytes? Or ask Teletask for more info?
+        // We need to complete toComponentState() here...
+        // Byte 0+1 = current temperature
+        // Byte 2+3 = target temperature
+        // Byte 4-11 = Unknown. Need to reverse engineer...
+        // Byte 12 = ON/OFF state (255/0)
+        // Byte 13-17 = Unknown. Need to reverse engineer...
+
+        return state;
+    }
+
+    @Override
+    public byte[] toBytes(ComponentState state) {
+        byte[] setting = null;
+        byte[] data = Bytes.EMPTY;
+
+        // TODO: implement commands with parameters: SETDAY,SETSTANDY,SETNIGHT,SETNIGHTCOOL ?
+
+        if (setting == null) {
+            setting = super.toBytes(state);
+        }
+
+        // TODO: Why is there a 0x00 byte in settings[0]?
+        setting = new byte[]{setting[1]};
+
+        return Bytes.concat(setting, data);
+
+    }
+
+    @Override
+    public boolean isValidState(ComponentState state) {
+        return state.getState() != null || super.isValidState(state);
+    }
+
+
+}

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/AurusStateCalculator.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/AurusStateCalculator.java
@@ -34,7 +34,7 @@ public class AurusStateCalculator extends MappingStateCalculator {
             new StateMapping("COOL", 96),
             new StateMapping("VENT", 105),
             new StateMapping("STOP", 106),
-            new StateMapping("HEATP", 107),
+            new StateMapping("HEATP", 107), // What is Heat+ ?
             new StateMapping("DRY", 108), // Undocumented, Not verified
             new StateMapping("ONOFF", 104)
     );
@@ -69,7 +69,7 @@ public class AurusStateCalculator extends MappingStateCalculator {
         byte[] setting = null;
         byte[] data = Bytes.EMPTY;
 
-        // TODO: implement commands with parameters: SETDAY,SETSTANDY,SETNIGHT,SETNIGHTCOOL
+        // TODO: implement other commands with parameters: SETDAY,SETSTANDBY,SETNIGHT,SETNIGHTCOOL
         if (state.getTargetTemperature() != null) {
             setting = super.toBytes(new ComponentState("MANUALTARGET"));
             try {

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/AurusStateCalculator.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/AurusStateCalculator.java
@@ -14,6 +14,7 @@ public class AurusStateCalculator extends MappingStateCalculator {
     private static final List<StateMapping> STATE_MAPPINGS = List.of(
             new StateMapping("UP", 21),
             new StateMapping("DOWN", 22),
+            new StateMapping("MANUALTARGET", 87), // Undocumented, verified
             new StateMapping("FROST", 24),
             new StateMapping("DAY", 26),
             new StateMapping("NIGHT",25 ),
@@ -22,7 +23,6 @@ public class AurusStateCalculator extends MappingStateCalculator {
 //            new StateMapping("SETSTANDBY", 88),
 //            new StateMapping("SETNIGHT", 27),
 //            new StateMapping("SETNIGHTCOOL", 56),
-//            new StateMapping("TEMPMANUAL_TARGET", 87), // Not verified yet
             new StateMapping("SPEED", 31),
             new StateMapping("SPLOW", 97),
             new StateMapping("SPMED", 98),
@@ -35,7 +35,7 @@ public class AurusStateCalculator extends MappingStateCalculator {
             new StateMapping("VENT", 105),
             new StateMapping("STOP", 106),
             new StateMapping("HEATP", 107),
-            new StateMapping("DRY", 108), // Not verified yet
+            new StateMapping("DRY", 108), // Undocumented, Not verified
             new StateMapping("ONOFF", 104)
     );
     public AurusStateCalculator(NumberConverter numberConverter) {
@@ -69,7 +69,16 @@ public class AurusStateCalculator extends MappingStateCalculator {
         byte[] setting = null;
         byte[] data = Bytes.EMPTY;
 
-        // TODO: implement commands with parameters: SETDAY,SETSTANDY,SETNIGHT,SETNIGHTCOOL,TEMPMANUAL_TARGET
+        // TODO: implement commands with parameters: SETDAY,SETSTANDY,SETNIGHT,SETNIGHTCOOL
+        if (state.getTargetTemperature() != null) {
+            setting = super.toBytes(new ComponentState("MANUALTARGET"));
+            try {
+                int temperature = (int) state.getTargetTemperature();
+                data = NumberConverter.UNSIGNED_SHORT.convert((temperature+273)*10);
+            } catch (NumberFormatException e) {
+                //Not a number, so no data is needed
+            }
+        }
 
         if (setting == null) {
             setting = super.toBytes(state);

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/DimmerStateCalculator.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/DimmerStateCalculator.java
@@ -3,10 +3,18 @@ package io.github.ridiekel.jeletask.client.builder.composer.config.statecalculat
 import io.github.ridiekel.jeletask.client.builder.composer.config.NumberConverter;
 import io.github.ridiekel.jeletask.client.spec.ComponentSpec;
 import io.github.ridiekel.jeletask.client.spec.state.ComponentState;
+import java.util.List;
 
-public class DimmerStateCalculator extends SimpleStateCalculator {
+public class DimmerStateCalculator extends MappingStateCalculator {
+
+    private static final List<StateMapping> STATE_MAPPINGS = List.of(
+            new StateMapping("ON", 100),
+            new StateMapping("OFF", 0),
+            new StateMapping("PREVIOUS_STATE", 103)
+    );
+
     public DimmerStateCalculator(NumberConverter numberConverter) {
-        super(numberConverter);
+        super(numberConverter, STATE_MAPPINGS.toArray(StateMapping[]::new));
     }
 
     @Override
@@ -15,9 +23,38 @@ public class DimmerStateCalculator extends SimpleStateCalculator {
     }
 
     @Override
+    public ComponentState toComponentState(ComponentSpec component, byte[] dataBytes) {
+        Number number = NumberConverter.UNSIGNED_BYTE.convert(new byte[]{dataBytes[0]});
+
+        ComponentState state = new ComponentState( (number.intValue() > 0) ? "ON" : "OFF");
+        state.setBrightness(number);
+
+        return state;
+    }
+
+    @Override
+    public byte[] toBytes(ComponentState state) {
+        if (state == null)
+            return null;
+
+        if (state.getBrightness() != null) {
+            // Brightness attribute always has priority
+            return NumberConverter.UNSIGNED_BYTE.convert(state.getBrightness());
+        }
+
+        return super.toBytes(new ComponentState(state.getState()));
+    }
+
+    @Override
     public boolean isValidState(ComponentState state) {
-        long value = Long.parseLong(state.getState());
-        return value == 103 || (value >= 0 && value <= 100);
+        boolean valid_brightness = false;
+
+        if (state.getBrightness() != null) {
+            byte brightness = state.getBrightness().byteValue();
+            valid_brightness = (brightness>=0 && brightness<=100);
+        }
+
+        return (state.getState() == null) ? valid_brightness : super.isValidState(state);
     }
 }
 

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/DisplayMessageStateCalculator.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/DisplayMessageStateCalculator.java
@@ -21,10 +21,8 @@ public class DisplayMessageStateCalculator extends SimpleStateCalculator {
         String str_msg2 = null;
 
         // Alarm requested? Set is_message to false.
-        if (state.getMessageType() != null) {
-            if (state.getMessageType().equalsIgnoreCase("alarm"))
+        if (state.getMessageType() != null || "alarm".equalsIgnoreCase(state.getMessageType()))
                 is_message = false;
-        }
 
         // msgType: 0x01 = message, 0x00 = alarm
         byte[] msgType = new byte[]{(byte)(is_message?1:0)};
@@ -32,12 +30,12 @@ public class DisplayMessageStateCalculator extends SimpleStateCalculator {
         if (state.getMessageLine1() != null)
             str_msg1 = StringUtils.left(state.getMessageLine1(), 16);
         else
-            str_msg1 = StringUtils.repeat(' ', 16);;
+            str_msg1 = StringUtils.repeat(' ', 16);
 
         if (state.getMessageLine2() != null)
             str_msg2 = StringUtils.left(state.getMessageLine2(), 16);
         else
-            str_msg2 = StringUtils.repeat(' ', 16);;
+            str_msg2 = StringUtils.repeat(' ', 16);
 
         // Create our message byte arrays
         bytes_msg1 = String.format("%-16s", str_msg1).getBytes();

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/DisplayMessageStateCalculator.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/DisplayMessageStateCalculator.java
@@ -1,0 +1,59 @@
+package io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator;
+
+import io.github.ridiekel.jeletask.client.builder.composer.config.NumberConverter;
+import io.github.ridiekel.jeletask.client.spec.state.ComponentState;
+import io.github.ridiekel.jeletask.utilities.Bytes;
+import org.apache.commons.lang3.StringUtils;
+
+public class DisplayMessageStateCalculator extends SimpleStateCalculator {
+
+    public DisplayMessageStateCalculator(NumberConverter numberConverter) {
+        super(numberConverter);
+    }
+
+    @Override
+    public byte[] toBytes(ComponentState state) {
+        byte[] bytes_msg1 = null;
+        byte[] bytes_msg2 = null;
+        byte[] beeps = null;
+        boolean is_message = true;  // Default = message
+        String str_msg1 = null;
+        String str_msg2 = null;
+
+        // Alarm requested? Set is_message to false.
+        if (state.getMessageType() != null) {
+            if (state.getMessageType().equalsIgnoreCase("alarm"))
+                is_message = false;
+        }
+
+        // msgType: 0x01 = message, 0x00 = alarm
+        byte[] msgType = new byte[]{(byte)(is_message?1:0)};
+
+        if (state.getMessageLine1() != null)
+            str_msg1 = StringUtils.left(state.getMessageLine1(), 16);
+        else
+            str_msg1 = StringUtils.repeat(' ', 16);;
+
+        if (state.getMessageLine2() != null)
+            str_msg2 = StringUtils.left(state.getMessageLine2(), 16);
+        else
+            str_msg2 = StringUtils.repeat(' ', 16);;
+
+        // Create our message byte arrays
+        bytes_msg1 = String.format("%-16s", str_msg1).getBytes();
+        bytes_msg2 = String.format("%-16s", str_msg2).getBytes();
+
+        // Beeps
+        if (state.getMessageBeeps() != null)
+            // How many beeps?
+            beeps = new byte[]{state.getMessageBeeps().byteValue()};
+        else
+            // Default: 1 beep
+            beeps = new byte[]{(byte)1};
+
+        boolean is_ascii = true; // true = ascii, false = unicode
+
+        return Bytes.concat(msgType, new byte[]{(byte)(is_ascii?1:0)}, bytes_msg1, bytes_msg2, beeps);
+    }
+
+}

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/InputStateCalculator.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/InputStateCalculator.java
@@ -17,18 +17,14 @@ public class InputStateCalculator extends SimpleStateCalculator {
         String state_str = "";
         int state = dataBytes[0]; // For digital input (TDS12117) -> 1 = Pulse?, 2 = Pressed, 3 = Released, 9 = Long pressed?
 
-        // Return the value by default
+        // Return the received value by default
         state_str = String.valueOf(dataBytes[0]);
 
-        switch (component.getService_type().toLowerCase()) {
-            case "digitalinput":
-                // TDS12117 ? 2 = pressed (contact closed) / 3 = released (contact open)
-                if (state == 2)
-                    state_str = "CLOSED";
-                else if (state == 3)
-                    state_str = "OPEN";
-                break;
-        }
+        // TDS12117 ? 2 = pressed (contact closed) / 3 = released (contact open)
+        if (state == 2)
+            state_str = "CLOSED";
+        else if (state == 3)
+            state_str = "OPEN";
 
         return new ComponentState(state_str);
     }

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/InputStateCalculator.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/InputStateCalculator.java
@@ -4,9 +4,9 @@ import io.github.ridiekel.jeletask.client.builder.composer.config.NumberConverte
 import io.github.ridiekel.jeletask.client.spec.ComponentSpec;
 import io.github.ridiekel.jeletask.client.spec.state.ComponentState;
 
-public class ServiceStateCalculator extends SimpleStateCalculator {
+public class InputStateCalculator extends SimpleStateCalculator {
 
-    public ServiceStateCalculator(NumberConverter numberConverter) {
+    public InputStateCalculator(NumberConverter numberConverter) {
         super(numberConverter);
     }
 

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/SensorStateCalculator.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/SensorStateCalculator.java
@@ -15,13 +15,14 @@ public class SensorStateCalculator extends SimpleStateCalculator {
 
     private final Map<String, StateCalculator> sensorTypeCalculators;
 
-    public SensorStateCalculator(StateCalculator temperature, StateCalculator lux, StateCalculator humidity, StateCalculator gas) {
+    public SensorStateCalculator(StateCalculator temperature, StateCalculator lux, StateCalculator humidity, StateCalculator gas, StateCalculator aurus) {
         super(temperature.getNumberConverter());
         this.sensorTypeCalculators = Map.of(
                 "TEMPERATURE", temperature,
                 "LIGHT", lux,
                 "HUMIDITY", humidity,
-                "GAS", gas
+                "GAS", gas,
+                "AURUS", aurus
         );
     }
 

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/SensorStateCalculator.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/SensorStateCalculator.java
@@ -15,14 +15,14 @@ public class SensorStateCalculator extends SimpleStateCalculator {
 
     private final Map<String, StateCalculator> sensorTypeCalculators;
 
-    public SensorStateCalculator(StateCalculator temperature, StateCalculator lux, StateCalculator humidity, StateCalculator gas, StateCalculator aurus) {
+    public SensorStateCalculator(StateCalculator temperature, StateCalculator lux, StateCalculator humidity, StateCalculator gas, StateCalculator temperaturecontrol) {
         super(temperature.getNumberConverter());
         this.sensorTypeCalculators = Map.of(
                 "TEMPERATURE", temperature,
                 "LIGHT", lux,
                 "HUMIDITY", humidity,
                 "GAS", gas,
-                "AURUS", aurus
+                "TEMPERATURECONTROL", temperaturecontrol
         );
     }
 

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/TemperatureControlStateCalculator.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/config/statecalculator/TemperatureControlStateCalculator.java
@@ -64,8 +64,12 @@ public class TemperatureControlStateCalculator extends MappingStateCalculator {
         // Byte 8 = Unknown (0x19 ?)
 
         state.setPreset(super.toComponentState(component, new byte[]{dataBytes[9]}).getState());
-        state.setMode(super.toComponentState(component, new byte[]{dataBytes[10]}).getState());
         state.setFanspeed(super.toComponentState(component, new byte[]{dataBytes[11]}).getState());
+
+        if ("OFF".equals(state.getState()))
+            state.setMode("OFF");
+        else
+            state.setMode(super.toComponentState(component, new byte[]{dataBytes[10]}).getState());
 
         // Byte 12 = ON/OFF (already used, see above)
 
@@ -85,7 +89,7 @@ public class TemperatureControlStateCalculator extends MappingStateCalculator {
         if (state.getTargetTemperature() != null) {
             setting = super.toBytes(new ComponentState("TARGET"));
             try {
-                int temperature = (int) state.getTargetTemperature();
+                int temperature = (int) state.getTargetTemperature().intValue();
                 data = NumberConverter.UNSIGNED_SHORT.convert((temperature+this.subtract)*this.divide);
             } catch (NumberFormatException e) {
                 //Not a number, so no data is needed
@@ -101,7 +105,7 @@ public class TemperatureControlStateCalculator extends MappingStateCalculator {
 
     @Override
     public boolean isValidState(ComponentState state) {
-        return state.getState() != null || super.isValidState(state);
+        return state.getTargetTemperature() != null || super.isValidState(state);
     }
 
 

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/microsplus/MicrosPlusCommandConfiguration.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/microsplus/MicrosPlusCommandConfiguration.java
@@ -9,6 +9,7 @@ import io.github.ridiekel.jeletask.client.builder.composer.config.configurables.
 import io.github.ridiekel.jeletask.client.builder.composer.config.configurables.command.KeepAliveCommandConfigurable;
 import io.github.ridiekel.jeletask.client.builder.composer.config.configurables.command.LogCommandConfigurable;
 import io.github.ridiekel.jeletask.client.builder.composer.config.configurables.command.SetCommandConfigurable;
+import io.github.ridiekel.jeletask.client.builder.composer.config.configurables.command.DisplayMessageCommandConfigurable;
 import io.github.ridiekel.jeletask.client.builder.message.messages.impl.EventMessage;
 import io.github.ridiekel.jeletask.client.builder.message.messages.impl.GetMessage;
 import io.github.ridiekel.jeletask.client.builder.message.messages.impl.SetMessage;

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/microsplus/MicrosPlusCommandConfiguration.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/microsplus/MicrosPlusCommandConfiguration.java
@@ -27,7 +27,8 @@ public class MicrosPlusCommandConfiguration extends ConfigurationSupport<Command
                 new GroupGetCommandConfigurable(9, true, "Central Unit", "Fnc", "Number", "Number"),
                 new LogCommandConfigurable(3, false, "Fnc", "State"),
                 new MicrosPlusEventCommandConfigurable(),
-                new KeepAliveCommandConfigurable(11, true)
+                new KeepAliveCommandConfigurable(11, true),
+                new DisplayMessageCommandConfigurable(4, true, "Central Unit")            
         ));
     }
 

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/microsplus/MicrosPlusFunctionConfiguration.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/microsplus/MicrosPlusFunctionConfiguration.java
@@ -13,6 +13,7 @@ import io.github.ridiekel.jeletask.client.builder.composer.config.statecalculato
 import io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator.StateCalculator;
 import io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator.TemperatureStateCalculator;
 import io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator.InputStateCalculator;
+import io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator.AurusStateCalculator;
 import io.github.ridiekel.jeletask.client.spec.Function;
 
 import java.util.List;
@@ -33,7 +34,8 @@ public class MicrosPlusFunctionConfiguration extends ConfigurationSupport<Functi
                         new TemperatureStateCalculator(NumberConverter.UNSIGNED_SHORT, 10, 273),
                         new LuxStateCalculator(NumberConverter.UNSIGNED_SHORT),
                         new HumidityStateCalculator(NumberConverter.UNSIGNED_SHORT),
-                        new GasStateCalculator(NumberConverter.UNSIGNED_SHORT)
+                        new GasStateCalculator(NumberConverter.UNSIGNED_SHORT),
+                        new AurusStateCalculator(NumberConverter.UNSIGNED_SHORT)
                 )),
                 new FunctionConfigurable(Function.COND, 60, ON_OFF_TOGGLE),
                 new FunctionConfigurable(Function.INPUT, 52, new InputStateCalculator(NumberConverter.UNSIGNED_SHORT)),

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/microsplus/MicrosPlusFunctionConfiguration.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/microsplus/MicrosPlusFunctionConfiguration.java
@@ -36,7 +36,7 @@ public class MicrosPlusFunctionConfiguration extends ConfigurationSupport<Functi
                         new GasStateCalculator(NumberConverter.UNSIGNED_SHORT)
                 )),
                 new FunctionConfigurable(Function.COND, 60, ON_OFF_TOGGLE),
-                new FunctionConfigurable(Function.SERVICE, 52, new ServiceStateCalculator(NumberConverter.UNSIGNED_SHORT)),
+                new FunctionConfigurable(Function.INPUT, 52, new ServiceStateCalculator(NumberConverter.UNSIGNED_SHORT)),
                 new FunctionConfigurable(Function.TIMEDFNC, 5, ON_OFF_TOGGLE)
         ));
     }

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/microsplus/MicrosPlusFunctionConfiguration.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/microsplus/MicrosPlusFunctionConfiguration.java
@@ -25,7 +25,7 @@ public class MicrosPlusFunctionConfiguration extends ConfigurationSupport<Functi
                         new LuxStateCalculator(NumberConverter.UNSIGNED_SHORT),
                         new HumidityStateCalculator(NumberConverter.UNSIGNED_SHORT),
                         new GasStateCalculator(NumberConverter.UNSIGNED_SHORT),
-                        new AurusStateCalculator(NumberConverter.UNSIGNED_BYTE)
+                        new TemperatureControlStateCalculator(NumberConverter.UNSIGNED_BYTE, 10, 273)
                 )),
                 new FunctionConfigurable(Function.COND, 60, ON_OFF_TOGGLE),
                 new FunctionConfigurable(Function.INPUT, 52, new InputStateCalculator(NumberConverter.UNSIGNED_SHORT)),

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/microsplus/MicrosPlusFunctionConfiguration.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/microsplus/MicrosPlusFunctionConfiguration.java
@@ -35,7 +35,7 @@ public class MicrosPlusFunctionConfiguration extends ConfigurationSupport<Functi
                         new LuxStateCalculator(NumberConverter.UNSIGNED_SHORT),
                         new HumidityStateCalculator(NumberConverter.UNSIGNED_SHORT),
                         new GasStateCalculator(NumberConverter.UNSIGNED_SHORT),
-                        new AurusStateCalculator(NumberConverter.UNSIGNED_SHORT)
+                        new AurusStateCalculator(NumberConverter.UNSIGNED_BYTE)
                 )),
                 new FunctionConfigurable(Function.COND, 60, ON_OFF_TOGGLE),
                 new FunctionConfigurable(Function.INPUT, 52, new InputStateCalculator(NumberConverter.UNSIGNED_SHORT)),

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/microsplus/MicrosPlusFunctionConfiguration.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/microsplus/MicrosPlusFunctionConfiguration.java
@@ -3,17 +3,7 @@ package io.github.ridiekel.jeletask.client.builder.composer.microsplus;
 import io.github.ridiekel.jeletask.client.builder.composer.config.ConfigurationSupport;
 import io.github.ridiekel.jeletask.client.builder.composer.config.NumberConverter;
 import io.github.ridiekel.jeletask.client.builder.composer.config.configurables.FunctionConfigurable;
-import io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator.DimmerStateCalculator;
-import io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator.HumidityStateCalculator;
-import io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator.GasStateCalculator;
-import io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator.LuxStateCalculator;
-import io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator.MotorStateCalculator;
-import io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator.OnOffToggleStateCalculator;
-import io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator.SensorStateCalculator;
-import io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator.StateCalculator;
-import io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator.TemperatureStateCalculator;
-import io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator.InputStateCalculator;
-import io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator.AurusStateCalculator;
+import io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator.*;
 import io.github.ridiekel.jeletask.client.spec.Function;
 
 import java.util.List;
@@ -39,7 +29,8 @@ public class MicrosPlusFunctionConfiguration extends ConfigurationSupport<Functi
                 )),
                 new FunctionConfigurable(Function.COND, 60, ON_OFF_TOGGLE),
                 new FunctionConfigurable(Function.INPUT, 52, new InputStateCalculator(NumberConverter.UNSIGNED_SHORT)),
-                new FunctionConfigurable(Function.TIMEDFNC, 5, ON_OFF_TOGGLE)
+                new FunctionConfigurable(Function.TIMEDFNC, 5, ON_OFF_TOGGLE),
+                new FunctionConfigurable(Function.DISPLAYMESSAGE, 54, new DisplayMessageStateCalculator(NumberConverter.UNSIGNED_BYTE))            
         ));
     }
 

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/microsplus/MicrosPlusFunctionConfiguration.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/composer/microsplus/MicrosPlusFunctionConfiguration.java
@@ -12,7 +12,7 @@ import io.github.ridiekel.jeletask.client.builder.composer.config.statecalculato
 import io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator.SensorStateCalculator;
 import io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator.StateCalculator;
 import io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator.TemperatureStateCalculator;
-import io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator.ServiceStateCalculator;
+import io.github.ridiekel.jeletask.client.builder.composer.config.statecalculator.InputStateCalculator;
 import io.github.ridiekel.jeletask.client.spec.Function;
 
 import java.util.List;
@@ -36,7 +36,7 @@ public class MicrosPlusFunctionConfiguration extends ConfigurationSupport<Functi
                         new GasStateCalculator(NumberConverter.UNSIGNED_SHORT)
                 )),
                 new FunctionConfigurable(Function.COND, 60, ON_OFF_TOGGLE),
-                new FunctionConfigurable(Function.INPUT, 52, new ServiceStateCalculator(NumberConverter.UNSIGNED_SHORT)),
+                new FunctionConfigurable(Function.INPUT, 52, new InputStateCalculator(NumberConverter.UNSIGNED_SHORT)),
                 new FunctionConfigurable(Function.TIMEDFNC, 5, ON_OFF_TOGGLE)
         ));
     }

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/builder/message/messages/impl/DisplayMessage.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/builder/message/messages/impl/DisplayMessage.java
@@ -1,0 +1,102 @@
+package io.github.ridiekel.jeletask.client.builder.message.messages.impl;
+
+import io.github.ridiekel.jeletask.client.TeletaskClientImpl;
+import io.github.ridiekel.jeletask.client.builder.composer.MessageHandler;
+import io.github.ridiekel.jeletask.client.builder.composer.config.configurables.FunctionConfigurable;
+import io.github.ridiekel.jeletask.client.builder.message.messages.AcknowledgeException;
+import io.github.ridiekel.jeletask.client.builder.message.messages.FunctionStateBasedMessageSupport;
+import io.github.ridiekel.jeletask.client.spec.CentralUnit;
+import io.github.ridiekel.jeletask.client.spec.Command;
+import io.github.ridiekel.jeletask.client.spec.ComponentSpec;
+import io.github.ridiekel.jeletask.client.spec.Function;
+import io.github.ridiekel.jeletask.client.spec.state.ComponentState;
+import io.github.ridiekel.jeletask.utilities.Bytes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class DisplayMessage extends FunctionStateBasedMessageSupport {
+    /**
+     * Logger responsible for logging and debugging statements.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(DisplayMessage.class);
+
+    private final int number;
+
+    private final byte[] bus_and_address_bytes;
+    private final byte[] displaymessage_bytes;
+
+    public DisplayMessage(CentralUnit clientConfig, Function function, int number, ComponentState state) {
+        super(clientConfig, function, state);
+        this.number = number;
+
+        FunctionConfigurable functionConfig = this.getMessageHandler().getFunctionConfig(this.getFunction());
+        ComponentSpec component = this.getClientConfig().getComponent(this.getFunction(), this.getNumber());
+
+        if (component.getAddressNumbers() == null || component.getBusNumbers() == null)
+            throw new IllegalArgumentException("Address or bus numbers are missing");
+
+        String busNumbers[] = component.getBusNumbers().split(",");
+        String addressNumbers[] = component.getAddressNumbers().split(",");
+
+        if (addressNumbers.length != busNumbers.length)
+            throw new IllegalArgumentException("Address and bus numbers configuration error");
+
+        byte[] busNumbers_bytes = Bytes.EMPTY;
+        for(String busNumber: busNumbers)
+            busNumbers_bytes = Bytes.concat(busNumbers_bytes, new byte[]{Byte.valueOf(busNumber)});
+
+        byte[] addressNumbers_bytes = Bytes.EMPTY;
+        for(String addressNumber: addressNumbers)
+            addressNumbers_bytes = Bytes.concat(addressNumbers_bytes, new byte[]{Byte.valueOf(addressNumber)});
+
+        this.bus_and_address_bytes = Bytes.concat(busNumbers_bytes, addressNumbers_bytes);
+        this.displaymessage_bytes = functionConfig.getStateCalculator(component).toBytes(this.getState());
+    }
+
+    public int getNumber() {
+        return this.number;
+    }
+
+    @Override
+    protected byte[] getPayload() {
+        return Bytes.concat(bus_and_address_bytes, displaymessage_bytes);
+    }
+
+    @Override
+    public void execute(TeletaskClientImpl client) throws AcknowledgeException {
+        super.execute(client);
+
+    }
+
+    @Override
+    protected Command getCommand() {
+        return Command.DISPLAYMESSAGE;
+    }
+
+    @Override
+    protected String[] getPayloadLogInfo() {
+        return new String[]{
+                this.formatFunction(this.getFunction()),
+                this.formatOutput(this.getNumber()),
+                this.formatState(this.displaymessage_bytes, this.getState())
+        };
+    }
+
+    @Override
+    public List<EventMessage> respond(CentralUnit config, MessageHandler messageHandler) {
+        return messageHandler.createResponseEventMessage(config, this.getFunction(), new MessageHandler.OutputState(this.getNumber(), this.getState()));
+    }
+
+    @Override
+    protected String getId() {
+        return "DISPLAYMESSAGE " + super.getId() + "(" + this.number + ")";
+    }
+
+    @Override
+    protected boolean isValid() {
+        FunctionConfigurable functionConfig = this.getMessageHandler().getFunctionConfig(this.getFunction());
+        return functionConfig.isValidState(this.getClientConfig().getComponent(this.getFunction(), this.getNumber()), this.getState());
+    }
+}

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/spec/Command.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/spec/Command.java
@@ -7,5 +7,6 @@ public enum Command {
     LOG,
     EVENT,
     KEEP_ALIVE,
-    GROUPGET;
+    GROUPGET,
+    DISPLAYMESSAGE;
 }

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/spec/ComponentSpec.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/spec/ComponentSpec.java
@@ -20,10 +20,7 @@ public class ComponentSpec  {
     private float gas_min = 0;
     private float gas_max = 0;
     private int gas_decimals = 0;
-
-    // For Teletask Service functions
-    private String service_type = "";
-    
+   
     /**
      * Default constructor.
      * The default constructor is used by Jackson.  In order not to have null values, some fields are initialised to empty strings.
@@ -103,7 +100,4 @@ public class ComponentSpec  {
 
     public void setGas_decimals(int gas_decimals) { this.gas_decimals = gas_decimals; }
     
-    public String getService_type() { return this.service_type; }
-
-    public void setService_type(String service_type) { this.service_type = service_type; }
 }

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/spec/ComponentSpec.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/spec/ComponentSpec.java
@@ -20,7 +20,12 @@ public class ComponentSpec  {
     private float gas_min = 0;
     private float gas_max = 0;
     private int gas_decimals = 0;
-   
+
+
+    // For DISPLAYMESSAGE
+    private String address_numbers;
+    private String bus_numbers;
+    
     /**
      * Default constructor.
      * The default constructor is used by Jackson.  In order not to have null values, some fields are initialised to empty strings.
@@ -99,5 +104,13 @@ public class ComponentSpec  {
     public int getGas_decimals() { return this.gas_decimals; }
 
     public void setGas_decimals(int gas_decimals) { this.gas_decimals = gas_decimals; }
+    
+    public String getAddressNumbers() { return this.address_numbers; }
+
+    public void setAddress_numbers(String numbers) { this.address_numbers = numbers; }
+
+    public String getBusNumbers() { return this.bus_numbers; }
+
+    public void setBus_numbers(String numbers) { this.bus_numbers = numbers; }
     
 }

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/spec/ComponentSpec.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/spec/ComponentSpec.java
@@ -3,7 +3,9 @@ package io.github.ridiekel.jeletask.client.spec;
 
 import io.github.ridiekel.jeletask.client.spec.state.ComponentState;
 
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * This class represents a Teletask component, being either a: relay, motor, mood, ... basically anything which can be controlled.
@@ -14,6 +16,9 @@ public class ComponentSpec  {
     private int number;
     private ComponentState state;
     private String type;
+
+    private String HAtype;
+    private String HA_unit_of_measurement;
     
     // For GAS (General Analog Sensor)
     private String gas_type = "";
@@ -25,7 +30,15 @@ public class ComponentSpec  {
     // For DISPLAYMESSAGE
     private String address_numbers;
     private String bus_numbers;
-    
+
+    public final Map<String, String> SensorTypesToHATypes = Map.of(
+            "TEMPERATURE", "sensor",
+            "LIGHT", "sensor",
+            "HUMIDITY", "sensor",
+            "GAS", "sensor"
+//            "TEMPERATURECONTROL", "climate"
+    );
+
     /**
      * Default constructor.
      * The default constructor is used by Jackson.  In order not to have null values, some fields are initialised to empty strings.
@@ -81,14 +94,30 @@ public class ComponentSpec  {
         this.description = description;
     }
 
-    public String getType() {
-        return this.type;
-    }
+    public String getType() { return this.type; }
 
     public void setType(String type) {
         this.type = type;
     }
-    
+
+    public String getHAType() {
+
+        if (this.HAtype == null) {
+
+            if (this.type != null)
+                return Optional.ofNullable(this.SensorTypesToHATypes.get(this.type)).orElse(this.type);
+
+            return this.type;
+
+        } else
+            return this.HAtype;
+
+    }
+
+    public void setHAType(String HAtype) {
+        this.HAtype = HAtype;
+    }
+
     public String getGas_type() { return this.gas_type; }
 
     public void setGas_type(String gas_type) { this.gas_type = gas_type; }
@@ -112,5 +141,9 @@ public class ComponentSpec  {
     public String getBusNumbers() { return this.bus_numbers; }
 
     public void setBus_numbers(String numbers) { this.bus_numbers = numbers; }
-    
+
+    public String getHA_unit_of_measurement() { return this.HA_unit_of_measurement; }
+
+    public void setHA_unit_of_measurement(String HA_unit_of_measurement) { this.HA_unit_of_measurement = HA_unit_of_measurement; }
+
 }

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/spec/ComponentSpec.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/spec/ComponentSpec.java
@@ -35,8 +35,8 @@ public class ComponentSpec  {
             "TEMPERATURE", "sensor",
             "LIGHT", "sensor",
             "HUMIDITY", "sensor",
-            "GAS", "sensor"
-//            "TEMPERATURECONTROL", "climate"
+            "GAS", "sensor",
+            "TEMPERATURECONTROL", "climate"
     );
 
     /**

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/spec/Function.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/spec/Function.java
@@ -17,7 +17,7 @@ public enum Function {
     FLAG("flag", state -> true),
     SENSOR("sensor value", state -> true),
     COND("condition", state -> true),
-    SERVICE("service", state -> true),
+    INPUT("input", state -> true),
     TIMEDFNC("timed function", state -> true);    
 
     private final String description;

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/spec/Function.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/spec/Function.java
@@ -18,7 +18,9 @@ public enum Function {
     SENSOR("sensor value", state -> true),
     COND("condition", state -> true),
     INPUT("input", state -> true),
-    TIMEDFNC("timed function", state -> true);    
+    TIMEDFNC("timed function", state -> true),
+    DISPLAYMESSAGE("Display message", state -> false);
+    
 
     private final String description;
     private final ShouldReceiveAcknowledge shouldReceiveAcknowledge;

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/spec/state/ComponentState.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/spec/state/ComponentState.java
@@ -22,6 +22,7 @@ public class ComponentState {
     private Number secondsToFinish;
     private Number correctionAtZeroPercentInSeconds;
     private Number correctionAtHundredPercentInSeconds;
+    private Number brightness;    
 
     public ComponentState() {
     }
@@ -89,6 +90,14 @@ public class ComponentState {
     public void setCorrectionAtHundredPercentInSeconds(Number correctionAtHundredPercentInSeconds) {
         this.correctionAtHundredPercentInSeconds = correctionAtHundredPercentInSeconds;
     }
+    
+    public Number getBrightness() {
+        return brightness;
+    }
+
+    public void setBrightness(Number brightness) {
+        this.brightness = brightness;
+    }    
 
     public static ComponentState parse(Function function, String state) {
         try {

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/spec/state/ComponentState.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/spec/state/ComponentState.java
@@ -31,6 +31,9 @@ public class ComponentState {
     // for AURUS
     private Number currentTemperature;
     private Number targetTemperature;
+    private String preset;
+    private String mode;
+    private String fanspeed;
 
     // For DISPLAYMESSAGE
     private String messageLine1;
@@ -119,10 +122,24 @@ public class ComponentState {
     public void setCurrentTemperature(Number temperature) {
         this.currentTemperature = temperature;
     }
-
     public Number getTargetTemperature() { return targetTemperature; }
     public void setTargetTemperature(Number temperature) {
         this.targetTemperature = temperature;
+    }
+
+    public String getPreset() { return preset; }
+    public void setPreset(String preset) {
+        this.preset = preset;
+    }
+
+    public String getMode() { return mode; }
+    public void setMode(String mode) {
+        this.mode = mode;
+    }
+
+    public String getFanspeed() { return fanspeed; }
+    public void setFanspeed(String fanspeed) {
+        this.fanspeed = fanspeed;
     }
 
     public String getMessageLine1() { return messageLine1; }

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/spec/state/ComponentState.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/spec/state/ComponentState.java
@@ -16,17 +16,28 @@ public class ComponentState {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL).setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
 
     private String state;
+
+    // For MOTOR
     private String lastDirection;
     private String protection;
     private Number position;
     private Number secondsToFinish;
     private Number correctionAtZeroPercentInSeconds;
     private Number correctionAtHundredPercentInSeconds;
+
+    // For DIMMER
     private Number brightness;
 
-    // for aurus
+    // for AURUS
     private Number currentTemperature;
     private Number targetTemperature;
+
+    // For DISPLAYMESSAGE
+    private String messageLine1;
+    private String messageLine2;
+    private Number messageBeeps;
+    private String messageType;
+
 
     public ComponentState() {
     }
@@ -109,11 +120,27 @@ public class ComponentState {
         this.currentTemperature = temperature;
     }
 
-    public Number getTargetTemperature() {
-        return targetTemperature;
-    }
+    public Number getTargetTemperature() { return targetTemperature; }
     public void setTargetTemperature(Number temperature) {
         this.targetTemperature = temperature;
+    }
+
+    public String getMessageLine1() { return messageLine1; }
+    public void setMessageLine1(String line) {
+        this.messageLine1 = line;
+    }
+
+    public String getMessageLine2() { return messageLine2; }
+    public void setMessageLine2(String line) {
+        this.messageLine2 = line;
+    }
+
+    public Number getMessageBeeps() { return messageBeeps; }
+    public void setMessageBeeps(Number beeps) { this.messageBeeps = beeps; }
+
+    public String getMessageType() { return messageType; }
+    public void setMessageType(String type) {
+        this.messageType = type;
     }
 
     public static ComponentState parse(Function function, String state) {

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/spec/state/ComponentState.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/spec/state/ComponentState.java
@@ -22,7 +22,11 @@ public class ComponentState {
     private Number secondsToFinish;
     private Number correctionAtZeroPercentInSeconds;
     private Number correctionAtHundredPercentInSeconds;
-    private Number brightness;    
+    private Number brightness;
+
+    // for aurus
+    private Number currentTemperature;
+    private Number targetTemperature;
 
     public ComponentState() {
     }
@@ -90,14 +94,27 @@ public class ComponentState {
     public void setCorrectionAtHundredPercentInSeconds(Number correctionAtHundredPercentInSeconds) {
         this.correctionAtHundredPercentInSeconds = correctionAtHundredPercentInSeconds;
     }
-    
+
     public Number getBrightness() {
         return brightness;
     }
-
     public void setBrightness(Number brightness) {
         this.brightness = brightness;
-    }    
+    }
+
+    public Number getCurrentTemperature() {
+        return currentTemperature;
+    }
+    public void setCurrentTemperature(Number temperature) {
+        this.currentTemperature = temperature;
+    }
+
+    public Number getTargetTemperature() {
+        return targetTemperature;
+    }
+    public void setTargetTemperature(Number temperature) {
+        this.targetTemperature = temperature;
+    }
 
     public static ComponentState parse(Function function, String state) {
         try {

--- a/client/src/main/java/io/github/ridiekel/jeletask/client/spec/state/ComponentState.java
+++ b/client/src/main/java/io/github/ridiekel/jeletask/client/spec/state/ComponentState.java
@@ -28,7 +28,7 @@ public class ComponentState {
     // For DIMMER
     private Number brightness;
 
-    // for AURUS
+    // for TEMPERATURECONTROL
     private Number currentTemperature;
     private Number targetTemperature;
     private String preset;

--- a/jeletask2mqtt/src/main/java/io/github/ridiekel/jeletask/mqtt/listener/MqttProcessor.java
+++ b/jeletask2mqtt/src/main/java/io/github/ridiekel/jeletask/mqtt/listener/MqttProcessor.java
@@ -237,7 +237,7 @@ public class MqttProcessor implements StateChangeListener {
             Map.entry(Function.TIMEDMOOD, f("scene", p -> {
                 return null;
             })),
-            Map.entry(Function.SERVICE, f("service", p -> {
+            Map.entry(Function.INPUT, f("service", p -> {
                 return null;
             })),
             Map.entry(Function.TIMEDFNC, f("button", p -> {

--- a/jeletask2mqtt/src/main/java/io/github/ridiekel/jeletask/mqtt/listener/MqttProcessor.java
+++ b/jeletask2mqtt/src/main/java/io/github/ridiekel/jeletask/mqtt/listener/MqttProcessor.java
@@ -204,7 +204,7 @@ public class MqttProcessor implements StateChangeListener {
     }
 
     private String haComponent(ComponentSpec c) {
-        return Optional.ofNullable(FUNCTION_TO_TYPE.get(c.getFunction())).map(f -> f.getType(c)).orElse("light");
+        return Optional.ofNullable(FUNCTION_TO_TYPE.get(c.getFunction())).map(f -> f.getHAType(c)).orElse("light");
     }
 
     private String haDiscoveryPrefix() {
@@ -231,9 +231,7 @@ public class MqttProcessor implements StateChangeListener {
             })),
             Map.entry(Function.MOTOR, f("cover", HAMotorConfig::new)),
             Map.entry(Function.RELAY, f("light", HARelayConfig::new)),
-            Map.entry(Function.SENSOR, f("sensor", p -> {
-                return null;
-            })),
+            Map.entry(Function.SENSOR, f("sensor", HASensorConfig::new)),
             Map.entry(Function.TIMEDMOOD, f("scene", p -> {
                 return null;
             })),
@@ -254,11 +252,11 @@ public class MqttProcessor implements StateChangeListener {
         private final java.util.function.Function<HAConfigParameters, HAConfig<?>> config;
 
         private FunctionConfig(String typeIfAbsent, java.util.function.Function<HAConfigParameters, HAConfig<?>> config) {
-            this.type = c -> Optional.ofNullable(c.getType()).orElse(typeIfAbsent);
+            this.type = c -> Optional.ofNullable(c.getHAType()).orElse(typeIfAbsent);
             this.config = config;
         }
 
-        public String getType(ComponentSpec componentSpec) {
+        public String getHAType(ComponentSpec componentSpec) {
             return this.type.apply(componentSpec);
         }
 
@@ -267,7 +265,7 @@ public class MqttProcessor implements StateChangeListener {
                     centralUnit,
                     componentSpec,
                     baseTopic,
-                    this.getType(componentSpec),
+                    this.getHAType(componentSpec),
                     identifier
             );
             return Optional.ofNullable(this.config.apply(params)).map(HAConfig::toString).orElse(null);

--- a/jeletask2mqtt/src/main/java/io/github/ridiekel/jeletask/mqtt/listener/MqttProcessor.java
+++ b/jeletask2mqtt/src/main/java/io/github/ridiekel/jeletask/mqtt/listener/MqttProcessor.java
@@ -239,9 +239,7 @@ public class MqttProcessor implements StateChangeListener {
             Map.entry(Function.INPUT, f("service", p -> {
                 return null;
             })),
-            Map.entry(Function.TIMEDFNC, f("button", p -> {
-                return null;
-            }))  
+            Map.entry(Function.TIMEDFNC, f("switch", HARelayConfig::new)) // timed functions actually  act like a relay so we can HA autodiscover them like a relay
     );
 
     static FunctionConfig f(String type, java.util.function.Function<HAConfigParameters, HAConfig<?>> config) {

--- a/jeletask2mqtt/src/main/java/io/github/ridiekel/jeletask/mqtt/listener/MqttProcessor.java
+++ b/jeletask2mqtt/src/main/java/io/github/ridiekel/jeletask/mqtt/listener/MqttProcessor.java
@@ -87,7 +87,13 @@ public class MqttProcessor implements StateChangeListener {
 
         this.connOpts = new MqttConnectOptions();
         this.connOpts.setMaxInflight(100000);
-        this.connOpts.setCleanSession(true);
+        
+        // TODO:
+        // Do we need CleanSession?
+        // I have disabled it for now because it's not subscribing to the mqtt topics again
+        // after a reconnect (for ex. when you restart your mqtt broker).
+        this.connOpts.setCleanSession(false);
+        
         this.connOpts.setAutomaticReconnect(true);
         this.connOpts.setUserName(username);
         this.connOpts.setPassword(password);

--- a/jeletask2mqtt/src/main/java/io/github/ridiekel/jeletask/mqtt/listener/MqttProcessor.java
+++ b/jeletask2mqtt/src/main/java/io/github/ridiekel/jeletask/mqtt/listener/MqttProcessor.java
@@ -342,9 +342,16 @@ public class MqttProcessor implements StateChangeListener {
                     String componentLog = getLoggingStringForComponent(MqttProcessor.this.teletaskClient.getConfig().getComponent(function, number));
                     LOG.info(String.format(WHAT_LOG_PATTERNS.get("COMMAND"), getWhat("COMMAND"), componentLog, payloadToLogWithColors(new String(mqttMessage.getPayload()))));
 
-                    MqttProcessor.this.teletaskClient.set(function, number, state,
-                            (f, n, s) -> LOG.debug(String.format("[%s] MQTT topic '%s' changed state for: %s / %s -> %s", componentLog, topic, f, n, s)),
-                            (f, n, s, e) -> LOG.warn(String.format("[%s] MQTT topic '%s' could not change state for: %s / %s -> %s", componentLog, topic, f, n, s)));
+                    if (function == Function.DISPLAYMESSAGE)
+                        MqttProcessor.this.teletaskClient.displaymessage(number, state,
+                                (f, n, s) -> LOG.debug(String.format("[%s] MQTT topic '%s' changed state for: %s / %s -> %s", componentLog, topic, f, n, s)),
+                                (f, n, s, e) -> LOG.warn(String.format("[%s] MQTT topic '%s' could not change state for: %s / %s -> %s", componentLog, topic, f, n, s)));
+
+                    else
+                        MqttProcessor.this.teletaskClient.set(function, number, state,
+                                (f, n, s) -> LOG.debug(String.format("[%s] MQTT topic '%s' changed state for: %s / %s -> %s", componentLog, topic, f, n, s)),
+                                (f, n, s, e) -> LOG.warn(String.format("[%s] MQTT topic '%s' could not change state for: %s / %s -> %s", componentLog, topic, f, n, s)));
+
                 }
             } catch (Exception e) {
                 if (LOG.isTraceEnabled()) {

--- a/jeletask2mqtt/src/main/java/io/github/ridiekel/jeletask/mqtt/listener/MqttProcessor.java
+++ b/jeletask2mqtt/src/main/java/io/github/ridiekel/jeletask/mqtt/listener/MqttProcessor.java
@@ -12,6 +12,7 @@ import io.github.ridiekel.jeletask.mqtt.listener.homeassistant.HAConfigParameter
 import io.github.ridiekel.jeletask.mqtt.listener.homeassistant.types.HADimmerConfig;
 import io.github.ridiekel.jeletask.mqtt.listener.homeassistant.types.HAMotorConfig;
 import io.github.ridiekel.jeletask.mqtt.listener.homeassistant.types.HARelayConfig;
+import io.github.ridiekel.jeletask.mqtt.listener.homeassistant.types.HASensorConfig;
 import org.apache.commons.lang3.StringUtils;
 import org.awaitility.Awaitility;
 import org.eclipse.paho.client.mqttv3.IMqttMessageListener;

--- a/jeletask2mqtt/src/main/java/io/github/ridiekel/jeletask/mqtt/listener/homeassistant/HAConfig.java
+++ b/jeletask2mqtt/src/main/java/io/github/ridiekel/jeletask/mqtt/listener/homeassistant/HAConfig.java
@@ -86,11 +86,17 @@ public class HAConfig<T extends HAConfig<T>> {
     public T putBoolean(String key, boolean value) {
         return this.putBoolean(this.config, key, value);
     }
-
     private T putBoolean(ObjectNode node, String key, boolean value) {
         node.put(key, value);
         return this.self();
     }
+
+    public T putDouble(String key, Double value) { return this.putDouble(this.config, key, value); }
+    private T putDouble(ObjectNode node, String key, Double value) {
+        node.put(key, value);
+        return this.self();
+    }
+
 
     public T putInt(String key, int value) {
         return this.putInt(this.config, key, value);

--- a/jeletask2mqtt/src/main/java/io/github/ridiekel/jeletask/mqtt/listener/homeassistant/types/HADimmerConfig.java
+++ b/jeletask2mqtt/src/main/java/io/github/ridiekel/jeletask/mqtt/listener/homeassistant/types/HADimmerConfig.java
@@ -6,13 +6,10 @@ import io.github.ridiekel.jeletask.mqtt.listener.homeassistant.HAReadWriteConfig
 public class HADimmerConfig extends HAReadWriteConfig<HADimmerConfig> {
     public HADimmerConfig(HAConfigParameters parameters) {
         super(parameters);
-        this.putInt("brightness_scale", 100);
-        this.put("on_command_type","brightness");
-        this.put("brightness_command_topic", "~/set");
-        this.put("brightness_state_topic", "~/state");
-        this.put("payload_on", "1");
-        this.put("payload_off", "0");
-        this.put("state_value_template", "{% if value_json.state|int > 0 %}1{% else %}0{% endif %}");
-        this.put("brightness_value_template", "{{ value_json.state|int }}");
+        this.put("schema", "template");
+        this.put("command_on_template", "{\"state\": {%- if brightness is not defined -%}\"PREVIOUS_STATE\"{%- else -%}\"ON\", \"brightness\": {{ (brightness / 255 * 100) | round(0) }}{%- endif -%}}");
+        this.put("command_off_template", "{\"state\": \"off\"}");
+        this.put("state_template", "{% if ( value_json.state|lower == 'on'  ) %}on{% else %}off{% endif %}");
+        this.put("brightness_template", "{{ ( value_json.brightness|int / 100 * 255 ) | round(0) }}");
     }
 }

--- a/jeletask2mqtt/src/main/java/io/github/ridiekel/jeletask/mqtt/listener/homeassistant/types/HARelayConfig.java
+++ b/jeletask2mqtt/src/main/java/io/github/ridiekel/jeletask/mqtt/listener/homeassistant/types/HARelayConfig.java
@@ -6,7 +6,7 @@ import io.github.ridiekel.jeletask.mqtt.listener.homeassistant.HAReadWriteConfig
 public class HARelayConfig extends HAReadWriteConfig<HARelayConfig> {
     public HARelayConfig(HAConfigParameters parameters) {
         super(parameters);
-        if ("light".equalsIgnoreCase(parameters.getComponentSpec().getType())) {
+        if (parameters.getComponentSpec().getType() == null || "light".equalsIgnoreCase(parameters.getComponentSpec().getType())) {
             this.put("state_value_template", "{{ value_json.state }}");
         } else {
             this.put("value_template", "{{ value_json.state }}");

--- a/jeletask2mqtt/src/main/java/io/github/ridiekel/jeletask/mqtt/listener/homeassistant/types/HASensorConfig.java
+++ b/jeletask2mqtt/src/main/java/io/github/ridiekel/jeletask/mqtt/listener/homeassistant/types/HASensorConfig.java
@@ -1,0 +1,48 @@
+package io.github.ridiekel.jeletask.mqtt.listener.homeassistant.types;
+
+import io.github.ridiekel.jeletask.mqtt.listener.homeassistant.HAConfigParameters;
+import io.github.ridiekel.jeletask.mqtt.listener.homeassistant.HAReadOnlyConfig;
+
+
+public class HASensorConfig extends HAReadOnlyConfig<HASensorConfig> {
+
+    public HASensorConfig(HAConfigParameters parameters) {
+        super(parameters);
+
+        if ("TEMPERATURECONTROL".equalsIgnoreCase(parameters.getComponentSpec().getType())) {
+            // HA 'climate'
+
+            this.putInt("min_temp", 10);
+            this.putInt("max_temp", 30);
+            this.putDouble("precision", 0.1);
+            this.put("current_temperature_topic", "~/state");
+            this.put("temperature_state_topic", "~/state");
+            this.put("temperature_command_topic", "~/set");
+            this.put("power_state_topic", "~/state");
+            this.put("power_command_topic", "~/set");
+            this.put("payload_on", "{\"state\": \"ON\"}");
+            this.put("payload_off", "{\"state\": \"OFF\"}");
+            this.put("mode_state_topic", "~/state");
+            this.put("mode_command_topic", "~/set");
+            this.put("fan_mode_state_topic", "~/state");
+            this.put("fan_mode_command_topic", "~/set");
+
+            this.put("current_temperature_template", "{{ value_json.current_temperature }}");
+            this.put("temperature_state_template", "{{ value_json.target_temperature }}");
+            this.put("temperature_command_template", "{\"target_temperature\": \"{{ value }}\"}");
+            this.put("mode_state_template", "{% if value_json.mode|upper == \"VENT\" %}fan_only{% else %}{{ value_json.mode|lower }}{% endif %}");
+            this.put("mode_command_template", "{% if value|lower == \"fan_only\" %}{\"state\": \"VENT\"}{% else %}{\"state\": \"{{ value | lower}}\"}{% endif %}");
+            this.put("fan_mode_command_template", "{% if value|lower == \"auto\" %}{\"state\": \"SPAUTO\"}{% elif value|lower == \"low\" %}{\"state\": \"SPLOW\"}{% elif value|lower == \"med\" %}{\"state\": \"SPMED\"}{% elif value|lower == \"high\" %}{\"state\": \"SPHIGH\"}{% endif %}");
+            this.put("fan_mode_state_template", "{% if value_json.fanspeed|upper == \"SPAUTO\" %}auto{% elif value_json.fanspeed|upper == \"SPLOW\" %}low{% elif value_json.fanspeed|upper == \"SPMED\" %}med{% elif value_json.fanspeed|upper == \"SPHIGH\" %}high{% endif %}");
+
+        } else {
+
+            // Regular simple sensor
+            if (parameters.getComponentSpec().getHA_unit_of_measurement() != null)
+                this.put("unit_of_measurement", parameters.getComponentSpec().getHA_unit_of_measurement());
+
+            this.put("value_template", "{{ value_json.state }}");
+        }
+
+    }
+}


### PR DESCRIPTION
Hey ridiekel,

This is still a work in progress. Please wait before merging it to master.

The things changed so far:

**Dimmers:**
- They now have separate "state" and "brightness" attributes in json. This simplified integration with HA
- HA dimmers auto discovery now uses these changed attributes and can turn on lights at the previous brightness state.

**Service functions:**
- I mistakenly called them 'service functions' in a previous PR. I was in the assumption I was using function id 53, which is for the service functions. But it was id 52 which is for the digital inputs only i think. My mistake, so I renamed SERVICE functions to INPUT now.

**MQTT:**
- bugfix: After restarting the mqtt broker jeletask needs to be restarted because it's no longer subscribed to the mqtt topics.
This has been fixed in this PR by setting this.connOpts.setCleanSession(false);.
I'm unsure if we need a "clean session" at all? If we do, we need to somehow make jeletask resubscribe to the mqtt topics after a reconnect. If not, this can be considered a permanent fix.
I haven't noticed any problems with this and I'm already using setCleanSession(false) for over 2 weeks...

**AURUS sensor/wall switch:**
- In Teletask an Aurus wall switch has a temperature sensor that can be connected to a HVAC and work like a thermostat. 
I'm adding support to control this "sensor" with those SET_TEMP* functions.
So far I can send ONOFF/UP/DOWN/HEAT/COOL/... with succes. 

- The toComponentState() function is still unfinished because I'm waiting for more API details from Teletask. 
I hope they will provide. If not, I will have to continue reverse engineering the protocol...

### **ISSUE**

**Dimmers:**
Dimmers now only accept json commands on the /set topic. I'm not sure how I could have broken this?
It should still be possible to send the string instead of json. But it looks like I broke it?

PS: do we still want to accept non-json?




