### PR TITLE
Estimated motor positions

### DIFF
--- a/jeletask2mqtt/src/main/java/io/github/ridiekel/jeletask/mqtt/listener/homeassistant/types/HAMotorConfig.java
+++ b/jeletask2mqtt/src/main/java/io/github/ridiekel/jeletask/mqtt/listener/homeassistant/types/HAMotorConfig.java
@@ -15,8 +15,8 @@ public class HAMotorConfig extends HAReadWriteConfig<HAMotorConfig> {
         this.put("payload_open", "{\"state\": \"UP\"}");
         this.put("payload_close", "{\"state\": \"DOWN\"}");
         this.put("payload_stop", "{\"state\": \"STOP\"}");
-        this.put("position_template", "{{ value_json.position }}");
+        this.put("position_template", "{{ value_json.current_position }}");
         this.put("set_position_template", "{\"position\": {{ 100 - position }}}");
-        this.put("value_template", "{% if value_json.state == 'OFF' %}{% if value_json.position == 100 %}closed{% elif value_json.position == 0 %}open{% else %}stopped{% endif %}{% else %}{% if value_json.last_direction == 'DOWN' %}closing{% else %}opening{% endif %}{% endif %}");
+        this.put("value_template", "{% if value_json.state == 'OFF' %}{% if value_json.current_position == 100 %}closed{% elif value_json.current_position == 0 %}open{% else %}stopped{% endif %}{% else %}{% if value_json.last_direction == 'DOWN' %}closing{% else %}opening{% endif %}{% endif %}");
     }
 }


### PR DESCRIPTION
See https://github.com/ridiekel/jeletask/issues/25

This change will make jeletask send estimated position and estimated secondsToFinish topics over mqtt when a motor is running. 

Note: maybe it's a good idea to add an option to turn this feature on/off before merging it to master?
I'm not sure if everyone want this and if it won't break things with other implementation besides Home Assitant.


